### PR TITLE
Added support for HTTPS and HTTP regex matching

### DIFF
--- a/django_steam/models.py
+++ b/django_steam/models.py
@@ -14,7 +14,7 @@ class UserSteam(models.Model):
 
 @receiver(post_save, sender=UserOpenID, dispatch_uid="save_steam_player")
 def save_steam_player(sender, instance, **kwargs):
-    regex = r'http://steamcommunity.com/openid/id/(\w+)'
+    regex = "https?://steamcommunity.com/openid/id/(\w+)"
     match = re.findall(regex, instance.claimed_id)
     if len(match) > 0:
         steam_id = match[0]


### PR DESCRIPTION
Current regex matching only recognizes http:// urls, but as I was developing my application, I was presented with https:// urls, so I added support to match both http and https.